### PR TITLE
Allow setting margin using MarginInfo

### DIFF
--- a/src/main/java/org/vaadin/addon/borderlayout/BorderLayout.java
+++ b/src/main/java/org/vaadin/addon/borderlayout/BorderLayout.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
+import com.vaadin.shared.ui.MarginInfo;
 import com.vaadin.ui.Component;
 import com.vaadin.ui.HorizontalLayout;
 import com.vaadin.ui.Label;
@@ -98,6 +99,17 @@ public class BorderLayout extends VerticalLayout {
 	public void setMargin(boolean margin) {
 		mainLayout.setMargin(margin);
 		markAsDirty();
+	}
+	
+	@Override
+	public void setMargin(MarginInfo marginInfo) {
+	    mainLayout.setMargin(marginInfo);
+	    markAsDirty();
+	}
+	
+	@Override
+	public MarginInfo getMargin() {
+	    return mainLayout.getMargin();
 	}
 
 	@Override


### PR DESCRIPTION
This fix allows setting the margin for each side individually. Without fix the margin is added on top of the margin set in the main layout. Because of this for example if a margin was added to the bottom, but previously the margin was set to `true`, it would keep the margin and add an extra margin on the bottom.